### PR TITLE
Release candidate 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # TS Redux Actions
-> Typed Redux Action Creators for TypeScript
+> Typesafe Redux Action Creators for TypeScript  
 
-From now on no type errors will sneak in unnoticed through your action creators!
+This lib is a part of [`react-redux-typescript`](https://github.com/piotrwitek/react-redux-typescript) library, which is a collection of valuable utilities commonly used across many TypeScript Projects. 
 
 - Semantic Versioning
-- No external dependencies
+- No third-party dependencies
 - Output separate bundles for your specific workflow needs:
   - ES5 + CommonJS - `main`
   - ES5 + ES-Modules - `module` 
@@ -14,7 +14,8 @@ From now on no type errors will sneak in unnoticed through your action creators!
 
 - [Installation](#installation)
 - [Motivation](#motivation)
-- [Usage](#usage)
+- [Get Started](#get-started)
+- [Features](#features)
 - [API](#api)
   - [createAction](#createaction)
   - [~~createActions~~](#createactions) (WIP)
@@ -39,12 +40,15 @@ $ yarn add ts-redux-actions
 
 ## Motivation
 
-I wasn't satisfied with the API design in [redux-actions](https://redux-actions.js.org/) because of separate payload & meta map callback functions. 
-It doesn't allow for correct type inference when using TypeScript and it will force you to do an extra effort for explicit type annotations and probably result in more boilerplate when trying to work around it.
+I wasn't satisfied with [redux-actions](https://redux-actions.js.org/) with TypeScript because of separate payload & meta map functions which makes it not idiomatic when using with static typing.  
+What I mean here is it will break your function definition type inference and intellisense in returned "action creator" function (e.g. named arguments will be renamed to generic names like a1, a2, etc... and function arity with optional parameters will break your function signature entirely).  
+It will force you to do an extra effort for explicit type annotations and probably result in more boilerplate when trying to work around it.
 
-The other common issue with `redux-actions` types and similar solutions are related to losing your function definition type inference and intellisense (named arguments and arity) in resulting "action creator" function which for me is unacceptable.
+---
 
-As a bonus there is a convenient `type` static property on every action creator for common reducer switch case scenarios (can be used to narrow "Discriminated Union" type):
+## Get Started
+
+> Important note: On every created "action creator" function there is a convenient `getType` static method for common reducer switch case scenarios like below (can be used to narrow "Discriminated Union" type just remember to add trailing `!` to strip undefined):
 ```ts
 const increment = createAction('INCREMENT');
 // const increment: (() => {
@@ -52,17 +56,13 @@ const increment = createAction('INCREMENT');
 // }) & { readonly type: "INCREMENT"; } << HERE
 
 switch (action.type) {
-  case increment.type:
+  case increment.getType()!:
     return state + 1;
   ...
   ...
   default: return state;
 }
 ```
-
----
-
-## Usage
 
 To highlight the difference in API design and the benefits of "action creator" type inference found in this solution let me show you some usage examples:
 
@@ -176,8 +176,8 @@ it('no payload', () => {
 });
 
 it('with payload', () => {
-  const add = createAction('ADD', (type: 'ADD') => (amount: number) =>
-    ({ type, payload: amount }),
+  const add = createAction('ADD',
+    (amount: number) => ({ type: 'ADD', payload: amount }),
   );
 
   expect(add(10)).toEqual({ type: 'ADD', payload: 10 });
@@ -185,9 +185,9 @@ it('with payload', () => {
 });
 
 it('with payload and meta', () => {
-  const notify = createAction('NOTIFY', (type: 'NOTIFY') =>
+  const notify = createAction('NOTIFY',
     (username: string, message: string) => ({
-      type,
+      type: 'NOTIFY',
       payload: { message: `${username}: ${message}` },
       meta: { username, message },
     }),

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   "scripts": {
     "reinstall": "rm -rf node_modules/ && yarn install",
     "clean": "rm -rf es5-commonjs/ es5-module/ jsnext/",
-    "prepublishOnly": "yarn run clean && yarn run reinstall && yarn run check && yarn run test && yarn run build",
+    "prepublishOnly": "npm run clean && npm run reinstall && npm run check && npm run test && npm run build",
     "check": "npm run lint & npm run tsc",
     "lint": "tslint --project './tsconfig.json'",
     "tsc": "tsc -p . --noEmit",
     "tsc:watch": "tsc -p . --noEmit -w",
     "test": "jest --config jest.config.json ./src",
     "test:watch": "jest --config jest.config.json ./src --watch",
-    "build": "yarn run build:commonjs & yarn run build:module & yarn run build:jsnext",
+    "build": "npm run build:commonjs & npm run build:module & npm run build:jsnext",
     "build:commonjs": "rm -rf es5-commonjs/ && tsc -p . --outDir es5-commonjs/",
     "build:module": "rm -rf es5-module/ && tsc -p . --outDir es5-module/ -m 'ES2015'",
     "build:jsnext": "rm -rf jsnext/ && tsc -p . --outDir jsnext/ -t 'ES2015'"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-redux-actions",
   "version": "1.0.0-beta5",
-  "description": "Typed Redux Actions for TypeScript Projects",
+  "description": "Typesafe Redux Action Creators for TypeScript",
   "author": "Piotr Witek <piotrek.witek@gmail.com> (http://piotrwitek.github.io)",
   "repository": "https://github.com/piotrwitek/ts-redux-actions",
   "homepage": "https://github.com/piotrwitek/ts-redux-actions",

--- a/src/create-action.spec.ts
+++ b/src/create-action.spec.ts
@@ -1,146 +1,127 @@
 import { createAction, getType } from '.';
 
-describe('Redux Utils', () => {
-  describe('createAction', () => {
+describe('createAction', () => {
 
-    it('no payload', () => {
-      const increment = createAction('INCREMENT');
+  it('no payload', () => {
+    const increment = createAction('INCREMENT');
 
-      const action: { type: 'INCREMENT' } = increment();
-      expect(action).toEqual({ type: 'INCREMENT' });
-      const type: 'INCREMENT' = increment.getType!();
-      const type2: 'INCREMENT' = getType(increment);
-      expect(type).toBe('INCREMENT');
-      expect(type2).toBe('INCREMENT');
-    });
+    const action: { type: 'INCREMENT' } = increment();
+    expect(action).toEqual({ type: 'INCREMENT' });
+    const type: 'INCREMENT' = increment.getType!();
+    expect(type).toBe('INCREMENT');
+  });
 
-    it('no payload alternative', () => {
-      const increment = createAction('INCREMENT', () => ({ type: 'INCREMENT' }));
+  it('no payload alternative', () => {
+    const increment = createAction('INCREMENT', () => ({ type: 'INCREMENT' }));
 
-      const action: { type: 'INCREMENT' } = increment();
-      expect(action).toEqual({ type: 'INCREMENT' });
-      const type: 'INCREMENT' = increment.getType!();
-      const type2: 'INCREMENT' = getType(increment);
-      expect(type).toBe('INCREMENT');
-      expect(type2).toBe('INCREMENT');
-    });
+    const action: { type: 'INCREMENT' } = increment();
+    expect(action).toEqual({ type: 'INCREMENT' });
+    const type: 'INCREMENT' = increment.getType!();
+    expect(type).toBe('INCREMENT');
+  });
 
-    it('with payload', () => {
-      const add = createAction('ADD',
-        (amount: number) => ({ type: 'ADD', payload: amount }),
-      );
+  it('with payload', () => {
+    const add = createAction('ADD',
+      (amount: number) => ({ type: 'ADD', payload: amount }),
+    );
 
-      const action: { type: 'ADD', payload: number } = add(10);
-      expect(action).toEqual({ type: 'ADD', payload: 10 });
-      const type: 'ADD' = add.getType!();
-      const type2: 'ADD' = getType(add);
-      expect(type).toBe('ADD');
-      expect(type2).toBe('ADD');
-    });
+    const action: { type: 'ADD', payload: number } = add(10);
+    expect(action).toEqual({ type: 'ADD', payload: 10 });
+    const type: 'ADD' = add.getType!();
+    expect(type).toBe('ADD');
+  });
 
-    it('with payload and meta', () => {
-      const notify = createAction('NOTIFY',
-        (username: string, message: string) => ({
-          type: 'NOTIFY',
-          payload: { message: `${username}: ${message}` },
-          meta: { username, message },
-        }),
-      );
-
-      const action: {
+  it('with payload and meta', () => {
+    const notify = createAction('NOTIFY',
+      (username: string, message: string) => ({
         type: 'NOTIFY',
-        payload: { message: string },
-        meta: { username: string, message: string },
-      } = notify('Piotr', 'Hello!');
-      expect(action).toEqual({
-        type: 'NOTIFY',
-        payload: { message: 'Piotr: Hello!' },
-        meta: { username: 'Piotr', message: 'Hello!' },
-      });
-      const type: 'NOTIFY' = notify.getType!();
-      const type2: 'NOTIFY' = getType(notify);
-      expect(type).toBe('NOTIFY');
-      expect(type2).toBe('NOTIFY');
+        payload: { message: `${username}: ${message}` },
+        meta: { username, message },
+      }),
+    );
+
+    const action: {
+      type: 'NOTIFY',
+      payload: { message: string },
+      meta: { username: string, message: string },
+    } = notify('Piotr', 'Hello!');
+    expect(action).toEqual({
+      type: 'NOTIFY',
+      payload: { message: 'Piotr: Hello!' },
+      meta: { username: 'Piotr', message: 'Hello!' },
     });
+    const type: 'NOTIFY' = notify.getType!();
+    expect(type).toBe('NOTIFY');
+  });
 
-    it('with payload and no params', () => {
-      const showNotification = createAction('SHOW_NOTIFICATION',
-        () => ({
-          type: 'SHOW_NOTIFICATION',
-          payload: 'default message',
-        }),
-      );
-
-      const action: { type: 'SHOW_NOTIFICATION', payload: string } = showNotification();
-      expect(action).toEqual({
+  it('with payload and no params', () => {
+    const showNotification = createAction('SHOW_NOTIFICATION',
+      () => ({
         type: 'SHOW_NOTIFICATION',
         payload: 'default message',
-      });
-      const type: 'SHOW_NOTIFICATION' = showNotification.getType!();
-      const type2: 'SHOW_NOTIFICATION' = getType(showNotification);
-      expect(type).toBe('SHOW_NOTIFICATION');
-      expect(type2).toBe('SHOW_NOTIFICATION');
+      }),
+    );
+
+    const action: { type: 'SHOW_NOTIFICATION', payload: string } = showNotification();
+    expect(action).toEqual({
+      type: 'SHOW_NOTIFICATION',
+      payload: 'default message',
     });
+    const type: 'SHOW_NOTIFICATION' = showNotification.getType!();
+    expect(type).toBe('SHOW_NOTIFICATION');
+  });
 
-    it('with payload and optional param', () => {
-      const showNotification = createAction('SHOW_NOTIFICATION',
-        (message?: string) => ({
-          type: 'SHOW_NOTIFICATION',
-          payload: message,
-        }),
-      );
-
-      const action: { type: 'SHOW_NOTIFICATION', payload: string | undefined } = showNotification();
-      expect(action).toEqual({
+  it('with payload and optional param', () => {
+    const showNotification = createAction('SHOW_NOTIFICATION',
+      (message?: string) => ({
         type: 'SHOW_NOTIFICATION',
-        payload: undefined,
-      });
-      const type: 'SHOW_NOTIFICATION' = showNotification.getType!();
-      const type2: 'SHOW_NOTIFICATION' = getType(showNotification);
-      expect(type).toBe('SHOW_NOTIFICATION');
-      expect(type2).toBe('SHOW_NOTIFICATION');
+        payload: message,
+      }),
+    );
+
+    const action: { type: 'SHOW_NOTIFICATION', payload: string | undefined } = showNotification();
+    expect(action).toEqual({
+      type: 'SHOW_NOTIFICATION',
+      payload: undefined,
     });
+    const type: 'SHOW_NOTIFICATION' = showNotification.getType!();
+    expect(type).toBe('SHOW_NOTIFICATION');
+  });
 
-    it('with meta and no params', () => {
-      const showError = createAction('SHOW_ERROR',
-        () => ({
-          type: 'SHOW_ERROR',
-          meta: { type: 'error' },
-        }),
-      );
-
-      const action: { type: 'SHOW_ERROR', meta: { type: string } } = showError();
-      expect(action).toEqual({
+  it('with meta and no params', () => {
+    const showError = createAction('SHOW_ERROR',
+      () => ({
         type: 'SHOW_ERROR',
         meta: { type: 'error' },
-      });
-      const type: 'SHOW_ERROR' = showError.getType!();
-      const type2: 'SHOW_ERROR' = getType(showError);
-      expect(type).toBe('SHOW_ERROR');
-      expect(type2).toBe('SHOW_ERROR');
+      }),
+    );
+
+    const action: { type: 'SHOW_ERROR', meta: { type: string } } = showError();
+    expect(action).toEqual({
+      type: 'SHOW_ERROR',
+      meta: { type: 'error' },
     });
+    const type: 'SHOW_ERROR' = showError.getType!();
+    expect(type).toBe('SHOW_ERROR');
+  });
 
-    it('with meta and optional param', () => {
-      const showError = createAction('SHOW_ERROR',
-        (message?: string) => ({
-          type: 'SHOW_ERROR',
-          payload: message,
-          meta: { type: 'error' },
-        }),
-      );
-
-      const action: { type: 'SHOW_ERROR', payload: string | undefined, meta: { type: string } } = showError();
-      expect(action).toEqual({
+  it('with meta and optional param', () => {
+    const showError = createAction('SHOW_ERROR',
+      (message?: string) => ({
         type: 'SHOW_ERROR',
-        payload: undefined,
+        payload: message,
         meta: { type: 'error' },
-      });
-      const type: 'SHOW_ERROR' = showError.getType!();
-      const type2: 'SHOW_ERROR' = getType(showError);
-      expect(type).toBe('SHOW_ERROR');
-      expect(type2).toBe('SHOW_ERROR');
-    });
+      }),
+    );
 
+    const action: { type: 'SHOW_ERROR', payload: string | undefined, meta: { type: string } } = showError();
+    expect(action).toEqual({
+      type: 'SHOW_ERROR',
+      payload: undefined,
+      meta: { type: 'error' },
+    });
+    const type: 'SHOW_ERROR' = showError.getType!();
+    expect(type).toBe('SHOW_ERROR');
   });
 
 });

--- a/src/create-action.spec.ts
+++ b/src/create-action.spec.ts
@@ -1,4 +1,4 @@
-import { createAction } from '.';
+import { createAction, getType } from '.';
 
 describe('Redux Utils', () => {
   describe('createAction', () => {
@@ -6,8 +6,23 @@ describe('Redux Utils', () => {
     it('no payload', () => {
       const increment = createAction('INCREMENT');
 
-      expect(increment()).toEqual({ type: 'INCREMENT' });
-      expect(increment.type).toBe('INCREMENT');
+      const action: { type: 'INCREMENT' } = increment();
+      expect(action).toEqual({ type: 'INCREMENT' });
+      const type: 'INCREMENT' = increment.getType!();
+      const type2: 'INCREMENT' = getType(increment);
+      expect(type).toBe('INCREMENT');
+      expect(type2).toBe('INCREMENT');
+    });
+
+    it('no payload alternative', () => {
+      const increment = createAction('INCREMENT', () => ({ type: 'INCREMENT' }));
+
+      const action: { type: 'INCREMENT' } = increment();
+      expect(action).toEqual({ type: 'INCREMENT' });
+      const type: 'INCREMENT' = increment.getType!();
+      const type2: 'INCREMENT' = getType(increment);
+      expect(type).toBe('INCREMENT');
+      expect(type2).toBe('INCREMENT');
     });
 
     it('with payload', () => {
@@ -15,8 +30,12 @@ describe('Redux Utils', () => {
         (amount: number) => ({ type: 'ADD', payload: amount }),
       );
 
-      expect(add(10)).toEqual({ type: 'ADD', payload: 10 });
-      expect(add.type).toBe('ADD');
+      const action: { type: 'ADD', payload: number } = add(10);
+      expect(action).toEqual({ type: 'ADD', payload: 10 });
+      const type: 'ADD' = add.getType!();
+      const type2: 'ADD' = getType(add);
+      expect(type).toBe('ADD');
+      expect(type2).toBe('ADD');
     });
 
     it('with payload and meta', () => {
@@ -28,12 +47,20 @@ describe('Redux Utils', () => {
         }),
       );
 
-      expect(notify('Piotr', 'Hello!')).toEqual({
+      const action: {
+        type: 'NOTIFY',
+        payload: { message: string },
+        meta: { username: string, message: string },
+      } = notify('Piotr', 'Hello!');
+      expect(action).toEqual({
         type: 'NOTIFY',
         payload: { message: 'Piotr: Hello!' },
         meta: { username: 'Piotr', message: 'Hello!' },
       });
-      expect(notify.type).toBe('NOTIFY');
+      const type: 'NOTIFY' = notify.getType!();
+      const type2: 'NOTIFY' = getType(notify);
+      expect(type).toBe('NOTIFY');
+      expect(type2).toBe('NOTIFY');
     });
 
     it('with payload and no params', () => {
@@ -43,13 +70,16 @@ describe('Redux Utils', () => {
           payload: 'default message',
         }),
       );
-      const result = showNotification();
 
-      expect(result).toEqual({
+      const action: { type: 'SHOW_NOTIFICATION', payload: string } = showNotification();
+      expect(action).toEqual({
         type: 'SHOW_NOTIFICATION',
         payload: 'default message',
       });
-      expect(showNotification.type).toBe('SHOW_NOTIFICATION');
+      const type: 'SHOW_NOTIFICATION' = showNotification.getType!();
+      const type2: 'SHOW_NOTIFICATION' = getType(showNotification);
+      expect(type).toBe('SHOW_NOTIFICATION');
+      expect(type2).toBe('SHOW_NOTIFICATION');
     });
 
     it('with payload and optional param', () => {
@@ -60,11 +90,15 @@ describe('Redux Utils', () => {
         }),
       );
 
-      expect(showNotification()).toEqual({
+      const action: { type: 'SHOW_NOTIFICATION', payload: string | undefined } = showNotification();
+      expect(action).toEqual({
         type: 'SHOW_NOTIFICATION',
         payload: undefined,
       });
-      expect(showNotification.type).toBe('SHOW_NOTIFICATION');
+      const type: 'SHOW_NOTIFICATION' = showNotification.getType!();
+      const type2: 'SHOW_NOTIFICATION' = getType(showNotification);
+      expect(type).toBe('SHOW_NOTIFICATION');
+      expect(type2).toBe('SHOW_NOTIFICATION');
     });
 
     it('with meta and no params', () => {
@@ -75,11 +109,15 @@ describe('Redux Utils', () => {
         }),
       );
 
-      expect(showError()).toEqual({
+      const action: { type: 'SHOW_ERROR', meta: { type: string } } = showError();
+      expect(action).toEqual({
         type: 'SHOW_ERROR',
         meta: { type: 'error' },
       });
-      expect(showError.type).toBe('SHOW_ERROR');
+      const type: 'SHOW_ERROR' = showError.getType!();
+      const type2: 'SHOW_ERROR' = getType(showError);
+      expect(type).toBe('SHOW_ERROR');
+      expect(type2).toBe('SHOW_ERROR');
     });
 
     it('with meta and optional param', () => {
@@ -91,12 +129,16 @@ describe('Redux Utils', () => {
         }),
       );
 
-      expect(showError()).toEqual({
+      const action: { type: 'SHOW_ERROR', payload: string | undefined, meta: { type: string } } = showError();
+      expect(action).toEqual({
         type: 'SHOW_ERROR',
         payload: undefined,
         meta: { type: 'error' },
       });
-      expect(showError.type).toBe('SHOW_ERROR');
+      const type: 'SHOW_ERROR' = showError.getType!();
+      const type2: 'SHOW_ERROR' = getType(showError);
+      expect(type).toBe('SHOW_ERROR');
+      expect(type2).toBe('SHOW_ERROR');
     });
 
   });

--- a/src/create-action.ts
+++ b/src/create-action.ts
@@ -19,20 +19,27 @@ export function createAction<T extends string,
   typeString: T | AC,
   creatorFunction?: AC,
 ): AC & TypeGetter<T> {
-  if (creatorFunction) {
+  let actionCreator: any;
+
+  if (creatorFunction != null) {
     if (typeof creatorFunction !== 'function') {
       throw new Error('second argument is not a function');
     }
 
-    const actionCreator: any = creatorFunction;
-    actionCreator.getType = () => typeString;
-
-    return actionCreator;
+    actionCreator = creatorFunction;
   } else {
-    const actionCreator: any =
-      () => ({ type: typeString });
-    actionCreator.getType = () => typeString;
-
-    return actionCreator;
+    actionCreator = () => ({ type: typeString });
   }
+
+  if (typeString != null) {
+    if (typeof typeString !== 'string') {
+      throw new Error('first argument is not a type string');
+    }
+
+    actionCreator.getType = () => typeString;
+  } else {
+    throw new Error('first argument is missing');
+  }
+
+  return actionCreator;
 }

--- a/src/create-action.ts
+++ b/src/create-action.ts
@@ -1,36 +1,37 @@
-export type ActionCreatorFunction<TS extends string> =
-  | ((...args: any[]) => { type: TS, payload?: any, meta?: any, error?: boolean });
+import { EmptyAction, FluxStandardAction, TypeGetter } from '.';
 
-export type TSActionCreator<AC, T extends string> = AC & {
-  readonly type: T,
-};
-
-export function createAction<TS extends string, AC extends (() => { type: TS })>(
-  typeString: TS,
-): TSActionCreator<AC, TS>;
-
-export function createAction<TS extends string, AC extends ActionCreatorFunction<TS>>(
-  typeString: TS,
+export function createAction<T extends string,
+  AC extends (...args: any[]) => FluxStandardAction<T>
+  >(
+  typeString: T,
   creatorFunction: AC,
-): TSActionCreator<AC, TS>;
+): AC & TypeGetter<T>;
 
-export function createAction<TS extends string, AC extends ActionCreatorFunction<TS>>(
-  typeString: TS,
+export function createAction<T extends string,
+  AC extends () => { type: T }
+  >(
+  typeString: T,
+): AC & TypeGetter<T>;
+
+export function createAction<T extends string,
+  AC extends (...args: any[]) => FluxStandardAction<T>
+  >(
+  typeString: T | AC,
   creatorFunction?: AC,
-): TSActionCreator<AC, TS> {
+): AC & TypeGetter<T> {
   if (creatorFunction) {
     if (typeof creatorFunction !== 'function') {
       throw new Error('second argument is not a function');
     }
 
     const actionCreator: any = creatorFunction;
-    actionCreator.type = typeString;
+    actionCreator.getType = () => typeString;
 
     return actionCreator;
   } else {
     const actionCreator: any =
       () => ({ type: typeString });
-    actionCreator.type = typeString;
+    actionCreator.getType = () => typeString;
 
     return actionCreator;
   }

--- a/src/get-type.spec.ts
+++ b/src/get-type.spec.ts
@@ -1,0 +1,90 @@
+import { createAction, getType } from '.';
+
+describe('getType', () => {
+
+  it('no payload', () => {
+    const increment = createAction('INCREMENT');
+
+    const type: 'INCREMENT' = getType(increment);
+    expect(type).toBe('INCREMENT');
+  });
+
+  it('no payload alternative', () => {
+    const increment = createAction('INCREMENT', () => ({ type: 'INCREMENT' }));
+
+    const type: 'INCREMENT' = getType(increment);
+    expect(type).toBe('INCREMENT');
+  });
+
+  it('with payload', () => {
+    const add = createAction('ADD',
+      (amount: number) => ({ type: 'ADD', payload: amount }),
+    );
+
+    const type: 'ADD' = getType(add);
+    expect(type).toBe('ADD');
+  });
+
+  it('with payload and meta', () => {
+    const notify = createAction('NOTIFY',
+      (username: string, message: string) => ({
+        type: 'NOTIFY',
+        payload: { message: `${username}: ${message}` },
+        meta: { username, message },
+      }),
+    );
+
+    const type: 'NOTIFY' = getType(notify);
+    expect(type).toBe('NOTIFY');
+  });
+
+  it('with payload and no params', () => {
+    const showNotification = createAction('SHOW_NOTIFICATION',
+      () => ({
+        type: 'SHOW_NOTIFICATION',
+        payload: 'default message',
+      }),
+    );
+
+    const type: 'SHOW_NOTIFICATION' = getType(showNotification);
+    expect(type).toBe('SHOW_NOTIFICATION');
+  });
+
+  it('with payload and optional param', () => {
+    const showNotification = createAction('SHOW_NOTIFICATION',
+      (message?: string) => ({
+        type: 'SHOW_NOTIFICATION',
+        payload: message,
+      }),
+    );
+
+    const type: 'SHOW_NOTIFICATION' = getType(showNotification);
+    expect(type).toBe('SHOW_NOTIFICATION');
+  });
+
+  it('with meta and no params', () => {
+    const showError = createAction('SHOW_ERROR',
+      () => ({
+        type: 'SHOW_ERROR',
+        meta: { type: 'error' },
+      }),
+    );
+
+    const type: 'SHOW_ERROR' = getType(showError);
+    expect(type).toBe('SHOW_ERROR');
+  });
+
+  it('with meta and optional param', () => {
+    const showError = createAction('SHOW_ERROR',
+      (message?: string) => ({
+        type: 'SHOW_ERROR',
+        payload: message,
+        meta: { type: 'error' },
+      }),
+    );
+
+    const type: 'SHOW_ERROR' = getType(showError);
+    expect(type).toBe('SHOW_ERROR');
+  });
+
+});

--- a/src/get-type.ts
+++ b/src/get-type.ts
@@ -3,5 +3,9 @@ export interface TypeGetter<T> { getType?: () => T }
 export function getType<T extends string>(
   f: ((...args: any[]) => { type: T }) & TypeGetter<T>,
 ): T {
-  return f.getType!();
+  if (f == null || f.getType == null) {
+    throw new Error('first argument is not a "ts-action-creator" instance');
+  }
+
+  return f.getType();
 }

--- a/src/get-type.ts
+++ b/src/get-type.ts
@@ -1,0 +1,7 @@
+export interface TypeGetter<T> { getType?: () => T }
+
+export function getType<T extends string>(
+  f: ((...args: any[]) => { type: T }) & TypeGetter<T>,
+): T {
+  return f.getType!();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,6 @@
 
 export * from './type-utils';
 export * from './redux-types';
+
+export * from './get-type';
 export * from './create-action';

--- a/src/redux-types.ts
+++ b/src/redux-types.ts
@@ -33,9 +33,9 @@ export type PayloadMetaAction<T extends string, P, M> = {
  * @template P - Payload Type
  * @template M - Meta Type
  */
-export type FluxStandardAction<T extends string, P, M = undefined> = {
+export type FluxStandardAction<T extends string, P = any, M = any> = {
   type: T;
-  payload: P | Error;
+  payload?: P;
   meta?: M,
   error?: boolean;
 };


### PR DESCRIPTION
New:
- getType - new helper method to get type of action creator in more "FP" way
```ts
// function getType(actionCreator: AC<T>): T
import { createAction, getType } from 'ts-redux-actions';

const increment = createAction('INCREMENT');
const type: 'INCREMENT' = getType(increment);
expect(type).toBe('INCREMENT');

// in reducer
switch (action.type) {
  case getType(increment):
    return state + 1;

  default: return state;
}
```

Change:
- createAction - return action creator instance type access using getType instance method
```ts
const increment = createAction('INCREMENT');
// now to get the type of action creator with imperative API use
expect(increment.getType!()).toBe('INCREMENT');
// or "FP" style
expect(getType(increment)).toBe('INCREMENT');
```

Update:
- added handling of few edge cases
- added more test cases and type correctness test cases